### PR TITLE
docs: fix README document links

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,16 +35,16 @@ SyncSpace는 조직 내부에서 파일을 안전하고 효율적으로 저장, 
 
 소프트웨어공학 과제 결과물은 아래 위치에서 확인할 수 있습니다.
 
-- **프로젝트 I 제안서**: `doc/proposal.md`
-- **프로젝트 II 품질 요소 추정서**: `doc/project2.md`
-- **프로젝트 III 프로젝트 관리 계획서**: `doc/project_plan.md`
-- **프로젝트 IV 요구사항 정의서**: `doc/requirements.md`
-- **프로젝트 설명 문서**: `README.md`
+- **프로젝트 I 제안서**: [doc/proposal.md](./doc/proposal.md)
+- **프로젝트 II 품질 요소 추정서**: [doc/project2.md](./doc/project2.md)
+- **프로젝트 III 프로젝트 관리 계획서**: [doc/project_plan.md](./doc/project_plan.md)
+- **프로젝트 IV 요구사항 정의서**: [doc/requirements.md](./doc/requirements.md)
+- **프로젝트 설명 문서**: [README.md](./README.md)
 
 추후 아래 산출물이 추가되면 README에도 계속 반영합니다.
 
-- **요구사항 분석서**: `doc/requirements_analysis.md`
-- **소프트웨어 설계서**: `doc/software_design.md`
+- **요구사항 분석서**: `doc/requirements_analysis.md` 예정
+- **소프트웨어 설계서**: `doc/software_design.md` 예정
 
 ---
 
@@ -61,3 +61,4 @@ se/
 │   ├── requirements_analysis.md      # 추후 추가
 │   └── software_design.md            # 추후 추가
 └── src/
+```


### PR DESCRIPTION
## 변경 사항

README.md의 과제 결과물 위치에서 문서 경로를 클릭 가능한 Markdown 링크 형식으로 수정했습니다.

### 수정 전

기존에는 문서 경로가 코드 형식으로 작성되어 있어 GitHub README에서 클릭 이동이 불가능했습니다.

```md
- **프로젝트 I 제안서**: `doc/proposal.md`
- **프로젝트 II 품질 요소 추정서**: `doc/project2.md`
- **프로젝트 III 프로젝트 관리 계획서**: `doc/project_plan.md`
- **프로젝트 IV 요구사항 정의서**: `doc/requirements.md`
- **프로젝트 설명 문서**: `README.md`