### PR TITLE
docs: align FileMetadata and Folder relationship

### DIFF
--- a/doc/requirements_analysis.md
+++ b/doc/requirements_analysis.md
@@ -17,6 +17,7 @@
 | 1.2 | 2026-05-09 | 최민서 | Use Case Diagram 분리, 클래스 관계 수정, 정적 분석 보완, 시퀀스 예외 흐름 추가 | 수정 |
 | 1.3 | 2026-05-09 | 최민서 | 관리자 정책 관리 Subflow 보완, 주요 시퀀스 다이어그램 예외 흐름 추가 | 수정 |
 | 1.4 | 2026-05-09 | 최민서 | Mermaid Sequence Diagram 렌더링 오류 수정 | 수정 |
+| 1.5 | 2026-05-16 | 최민서 | CRC 카드와 클래스 다이어그램 간 FileMetadata-Folder 관계 일관성 보완 | 수정 |
 
 ---
 
@@ -1031,6 +1032,7 @@ classDiagram
 
     Folder "1" --> "0..*" File
     Folder "1" --> "0..*" Folder
+    Folder "1" --> "0..*" FileMetadata : contains metadata
 
     File "1" --> "1" FileMetadata
     File "1" --> "0..*" FileVersion
@@ -1169,6 +1171,7 @@ classDiagram
 | 폴더 삭제 | User |
 | 파일 포함 | File |
 | 하위 폴더 포함 | Folder |
+| 폴더 기준 파일 위치 정보 제공 | FileMetadata |
 
 **Attributes**
 
@@ -1181,7 +1184,7 @@ classDiagram
 
 - Generalization: 없음
 - Aggregation: File, Folder
-- Other Associations: User, Permission
+- Other Associations: User, Permission, FileMetadata
 
 ---
 


### PR DESCRIPTION
## 수정 내용

요구사항 분석서에 대한 피드백을 반영하여 CRC 카드와 클래스 다이어그램 간의 클래스 관계 일관성을 보완했습니다.

## 상세 수정 사항

- 제/개정 이력에 v1.5 수정 내역 추가
- 클래스 다이어그램에 `Folder`와 `FileMetadata` 간 관계선 추가
- `Folder` CRC 카드의 Collaborators에 `FileMetadata` 관련 책임 보완
- `Folder` 클래스의 Relationships 항목에 `FileMetadata` 연관 관계 추가

## 수정 이유

기존 CRC 카드에서는 `FileMetadata`가 파일 위치 정보 제공을 위해 `Folder`와 협력하는 것으로 명시되어 있었으나, 클래스 다이어그램에는 두 클래스 간 관계선이 표현되어 있지 않았습니다.  
이에 따라 두 산출물 간의 일관성을 맞추기 위해 `Folder`와 `FileMetadata` 간 관계를 클래스 다이어그램과 CRC 카드에 함께 반영했습니다.
