### PR TITLE
docs: fix aggregation relationship inconsistency

### DIFF
--- a/doc/requirements_analysis.md
+++ b/doc/requirements_analysis.md
@@ -18,6 +18,7 @@
 | 1.3 | 2026-05-09 | 최민서 | 관리자 정책 관리 Subflow 보완, 주요 시퀀스 다이어그램 예외 흐름 추가 | 수정 |
 | 1.4 | 2026-05-09 | 최민서 | Mermaid Sequence Diagram 렌더링 오류 수정 | 수정 |
 | 1.5 | 2026-05-16 | 최민서 | CRC 카드와 클래스 다이어그램 간 FileMetadata-Folder 관계 일관성 보완 | 수정 |
+| 1.6 | 2026-05-18 | 최민서 | FileMetadata 및 FileVersion CRC 카드의 Aggregation 관계 모순 수정 | 수정 |
 
 ---
 
@@ -1217,8 +1218,8 @@ classDiagram
 **Relationships**
 
 - Generalization: 없음
-- Aggregation: File
-- Other Associations: Folder, User
+- Aggregation: 없음
+- Other Associations: File, Folder, User
 
 ---
 
@@ -1317,8 +1318,8 @@ classDiagram
 **Relationships**
 
 - Generalization: 없음
-- Aggregation: File
-- Other Associations: User, Storage
+- Aggregation: 없음
+- Other Associations: File, User, Storage
 
 ---
 


### PR DESCRIPTION
## 수정 내용

요구사항 분석서에 대한 피드백을 반영하여 CRC 카드의 Aggregation 관계 표현을 수정했습니다.

## 상세 수정 사항

- 제/개정 이력에 v1.6 수정 내역 추가
- `FileMetadata` CRC 카드의 Relationships 항목 수정
- `FileVersion` CRC 카드의 Relationships 항목 수정
- `File`이 전체 객체이고 `FileMetadata`, `FileVersion`이 부분 객체라는 관계 방향을 유지하도록 정리

## 수정 이유

기존 문서에서는 `File` CRC 카드에 `Aggregation: FileMetadata, FileVersion`으로 작성되어 있어 `File`이 전체 객체이고 `FileMetadata`, `FileVersion`이 부분 객체임을 나타내고 있었습니다.

하지만 `FileMetadata`와 `FileVersion` CRC 카드에서도 각각 `Aggregation: File`로 작성되어 있어, 양방향 Aggregation 관계처럼 보일 수 있는 모순이 있었습니다.

이에 따라 `FileMetadata`와 `FileVersion` 카드의 Aggregation 항목은 `없음`으로 수정하고, `File`과의 관계는 `Other Associations`에 포함하여 일반 연관 관계로 정리했습니다.
